### PR TITLE
Fixed check if process is undefined

### DIFF
--- a/util.js
+++ b/util.js
@@ -106,7 +106,7 @@ exports.deprecate = function(fn, msg) {
 var debugs = {};
 var debugEnvRegex = /^$/;
 
-if (process.env.NODE_DEBUG) {
+if (typeof process !== 'undefined' && process.env.NODE_DEBUG) {
   var debugEnv = process.env.NODE_DEBUG;
   debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
     .replace(/\*/g, '.*')


### PR DESCRIPTION
Sometimes there's no process variable in the runtime (like in the browser), so it should be checked before accessing it deeper.